### PR TITLE
fix clear command not found and git exclude install folder

### DIFF
--- a/4.2/.gitignore
+++ b/4.2/.gitignore
@@ -1,0 +1,1 @@
+install/

--- a/4.3/.gitignore
+++ b/4.3/.gitignore
@@ -1,0 +1,1 @@
+install/

--- a/4.3/Dockerfile
+++ b/4.3/Dockerfile
@@ -10,7 +10,7 @@ LABEL author="Mike Howles" \
 USER root
 
 # Prerequisite
-RUN yum install -y glibc-2.28-101.el8.i686 libstdc++-8.3.1-5.el8.0.2.x86_64 libstdc++-8.3.1-5.el8.0.2.i686 libnsl-2.28-101.el8.i686 libcrypt.so.1 xz-libs-5.2.4-3.el8.i686 libnsl-2.28-101.el8.i686 libnsl.x86_64 
+RUN yum install -y ncurses glibc-2.28-101.el8.i686 libstdc++-8.3.1-5.el8.0.2.x86_64 libstdc++-8.3.1-5.el8.0.2.i686 libnsl-2.28-101.el8.i686 libcrypt.so.1 xz-libs-5.2.4-3.el8.i686 libnsl-2.28-101.el8.i686 libnsl.x86_64 
 
 ENV LANG=en_US.utf8
 ENV LC_ALL=en_US.utf8


### PR DESCRIPTION
Hello

Here is a little PR to fix the #1 issue I have opened before.

It seems that's the `centos:centos8` docker image doesn't come with the `clear` command line tool, but `ncurses` package provide that.

I have also added some `.gitignore` files to avoid pushing the BOBJ installation ;)